### PR TITLE
Two potentially helpful additions to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -14,8 +14,12 @@ HISTFILE=~/.histfile
 HISTSIZE=10000
 SAVEHIST=10000
 
-#Disbale stupid audible bell
+#Disable stupid audible bell
 unsetopt beep
+
+#Silence system bell when using less pager
+alias less='less -Q'
+alias man='man -P "less -Q"'
 
 #Set keybindings as VIM
 bindkey -v

--- a/.zshrc
+++ b/.zshrc
@@ -39,6 +39,9 @@ zstyle ':vcs_info:*' actionformats '%F{5}(%f%s%F{5})%F{3}-%F{5}[%F{2}%b%F{3}|%F{
 zstyle ':vcs_info:*' formats '%F{5}(%f%s%F{5})%F{3}-%F{5}[%F{2}%b%F{5}]%f '
 zstyle ':vcs_info:(git):*' branchformat '%b%F{1}:%F{3}%r'
 
+#Git log enhancement
+alias glog='git log --graph --decorate --pretty=oneline --abbrev-commit --all'
+
 #Prompt
 #Right hand side of prompt
 RPROMPT=$'%.%'


### PR DESCRIPTION
Here's a couple of zsh embellishments I've found recently you might like.

The first one silences the system bell in the less pager, since the system-wide setting doesn't work for a lot of people.

The second one shows a color-coded, compact view of a branch's history in a git repository.